### PR TITLE
remove SPI from includes

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph= Allows the programmer to use the LED matrix as a pixel addressable di
 category=Device Control
 url=https://github.com/MajicDesigns/MD_MAX72XX
 architectures=*
-includes=MD_MAX72xx.h,SPI.h
+includes=MD_MAX72xx.h
 license=LGPL-2.1


### PR DESCRIPTION
SPI.h is not provided by this library. 
It may confuses the library resolver of arduino-cli by thinking we provide this header.